### PR TITLE
Clean up same sequence normalization

### DIFF
--- a/src/lib/alleles.ml
+++ b/src/lib/alleles.ml
@@ -136,6 +136,8 @@ module Set = struct
   let set { to_index; _ } s allele =
     BitSet.set s (SMap.find allele to_index)
 
+  let unite ~into from = BitSet.unite into from
+
   let singleton index allele =
     let s = init index in
     set index s allele;

--- a/src/lib/alleles.mli
+++ b/src/lib/alleles.mli
@@ -31,6 +31,8 @@ module Set : sig
       *)
   val set : index -> t -> allele -> unit
 
+  val unite : into:t -> t -> unit
+
   (** [clear index t allele] will make sure that [allele] is not
       in [t], specifically [is_set index t allele] will be
       [false]. *)

--- a/src/lib/kmer_to_int.mli
+++ b/src/lib/kmer_to_int.mli
@@ -1,21 +1,21 @@
-(** Constructing a bijection between a k-mer and [0, 4^k). 
- 
+(** Constructing a bijection between a k-mer and [0, 4^k).
+
     Failure is via Invalid_argument exceptions. *)
 
 val char_to_int : char -> int
-(** [char_to_int c] converts a nucleotide [c] code to an integer. 
- 
+(** [char_to_int c] converts a nucleotide [c] code to an integer.
+
     @raise Invalid_argument if char is not 'A', 'C', 'G' or 'T' *)
 
 val int_to_char : int -> char
 (** [int_to_char i] converts an integer [i] to the appropriate nucleotide,
     reversing [char_to_int].
-    
+
     @raise Invalid_argument if argument is outside of [0,3]. *)
 
 val encode : ?pos:int -> ?len:int -> ?ext:int -> string -> int
 (** [encode text] converts the nucleotides in [text] to a unique integer.
- 
+
     @param pos  Which position in [text] to start encoding (defaults to 0).
     @param len  How many positions of [text] to encode (defaults to length of
                  [text]).
@@ -28,7 +28,7 @@ val encode : ?pos:int -> ?len:int -> ?ext:int -> string -> int
 val decode : k:int -> int -> string
 (** [decode ~k p] converts the integer pattern of [p] which encodes a kmer of
     length [k] back to a string of nuceotides. Reverses [decode]. *)
- 
+
 val reverse_complement : k:int -> int -> int
 (** [reverse_complement k p] computes the pattern of [p]'s reverse complement,
     where [p] is a pattern for a [k]-mer. *)

--- a/src/lib/ref_graph.ml
+++ b/src/lib/ref_graph.ml
@@ -109,6 +109,8 @@ type t =
   - When constructing the dot files, it would be nice if the alleles (edges),
     were in some kind of consistent order. *)
 
+(** [starts_by_position g] returns an associated list of alignment_position and
+    an a set of alleles that start at that position. *)
 let starts_by_position { aindex; bounds; _ } =
   Alleles.Map.fold aindex bounds ~init:[] ~f:(fun asc sep_lst allele ->
     List.fold_left sep_lst ~init:asc ~f:(fun asc sep ->
@@ -120,7 +122,9 @@ let starts_by_position { aindex; bounds; _ } =
       with Not_found ->
         (pos, Alleles.Set.singleton aindex allele) :: asc))
 
-let create_compressed g =
+(** Compress the start nodes; join all the start nodes that have the same
+    alignment position into one node. *)
+let create_compressed_starts g =
   let start_asc = starts_by_position g in
   let ng = G.copy g.g in
   let open Nodes in
@@ -155,7 +159,7 @@ let insert_newline ?(every=120) ?(token=';') s =
 
 let output_dot ?(human_edges=true) ?(compress_edges=true) ?(compress_start=true)
   ?(insert_newlines=true) ?short ?max_length fname t =
-  let { aindex; g; _} = if compress_start then create_compressed t else t in
+  let { aindex; g; _} = if compress_start then create_compressed_starts t else t in
   let oc = open_out fname in
   let module Dot = Graphviz.Dot (
     struct

--- a/src/lib/ref_graph.ml
+++ b/src/lib/ref_graph.ml
@@ -640,6 +640,17 @@ module FoldAtSamePosition = struct
 
 end (* FoldAtSamePosition *)
 
+(** [range g] returns the minimum and maximum alignment position in [g]. *)
+let range { aindex; bounds; _ } =
+  Alleles.Map.fold aindex bounds ~init:(max_int, min_int)
+    ~f:(fun p sep_lst _allele ->
+          List.fold_left sep_lst ~init:p ~f:(fun (st, en) sep ->
+            (min st (fst sep.start)), (max en sep.end_)))
+ 
+(*  
+  let create_by_position {g; aindex; } =
+  *)
+
 module JoinSameSequencePaths = struct
 
   (* Alignment and sequence pair set used as queue *)

--- a/src/scripts/adjacents.ml
+++ b/src/scripts/adjacents.ml
@@ -19,13 +19,7 @@ let test_file file =
   let open Ref_graph in
   let all_args = all_args ~file:(root_dir // "alignments" // (file ^ ".txt")) () in
   let g = Cache.graph all_args in
-  let st, en =
-     g.bounds
-     |> Alleles.Map.fold g.aindex ~init:(max_int, min_int)
-        ~f:(fun p sep_lst _allele ->
-            List.fold_left sep_lst ~init:p ~f:(fun (st, en) sep ->
-              (min st (fst sep.Ref_graph.start)), (max en sep.Ref_graph.end_)))
-  in
+  let st, en = Ref_graph.range g in
   for i = st to en - 1 do
     printf "------------testing %d -------------\n" i;
     test_graph g i


### PR DESCRIPTION
This PR refines this normalization pass, so that I can't find any warts (like #4) in A_nuc or B_nuc.