### PR TITLE
Filter short circuit

### DIFF
--- a/src/app/explore_alignment.ml
+++ b/src/app/explore_alignment.ml
@@ -9,20 +9,24 @@ let app_name = "explore_alignment"
 let unwrap_sf = function | `Stopped r | `Finished r -> r
 
 let mismatches_from ?(verbose=false) (gall, idx) seq =
+  let stop = float (String.length seq) in
+  let n = Ref_graph.number_of_alleles gall in
   Index.lookup idx seq >>= fun lst ->
     if verbose then printf "%d positions %!" (List.length lst);
     List.fold_left lst ~init:(Ok [])
       ~f:(fun ac_err p -> ac_err >>= fun acc ->
-            Alignment.compute_mismatches gall (String.length seq) seq p >>= fun al ->
+            Alignment.compute_mismatches gall (n, stop) seq p >>= fun al ->
               let al = unwrap_sf al in
               Ok ((p, al) :: acc))
     >>= fun lst -> Ok (seq, lst)
 
 let mismatches_from_lst (gall, idx) seq =
+  let stop = float (String.length seq) in
+  let n = Ref_graph.number_of_alleles gall in
   Index.lookup idx seq >>= fun lst ->
       List.fold_left lst ~init:(Ok [])
         ~f:(fun ac_err p -> ac_err >>= fun acc ->
-              Alignment.compute_mismatches_lst gall (String.length seq) seq p >>= fun al ->
+              Alignment.compute_mismatches_lst gall (n, stop) seq p >>= fun al ->
                 let al = unwrap_sf al in
                 Ok ((p, al) :: acc))
       >>= fun lst -> Ok (seq, lst)

--- a/src/app/explore_alignment.ml
+++ b/src/app/explore_alignment.ml
@@ -6,12 +6,15 @@ open Util
 let repo = "prohlatype"
 let app_name = "explore_alignment"
 
+let unwrap_sf = function | `Stopped r | `Finished r -> r
+
 let mismatches_from ?(verbose=false) (gall, idx) seq =
   Index.lookup idx seq >>= fun lst ->
     if verbose then printf "%d positions %!" (List.length lst);
     List.fold_left lst ~init:(Ok [])
       ~f:(fun ac_err p -> ac_err >>= fun acc ->
-            Alignment.compute_mismatches gall seq p >>= fun al ->
+            Alignment.compute_mismatches gall (String.length seq) seq p >>= fun al ->
+              let al = unwrap_sf al in
               Ok ((p, al) :: acc))
     >>= fun lst -> Ok (seq, lst)
 
@@ -19,7 +22,8 @@ let mismatches_from_lst (gall, idx) seq =
   Index.lookup idx seq >>= fun lst ->
       List.fold_left lst ~init:(Ok [])
         ~f:(fun ac_err p -> ac_err >>= fun acc ->
-              Alignment.compute_mismatches_lst gall seq p >>= fun al ->
+              Alignment.compute_mismatches_lst gall (String.length seq) seq p >>= fun al ->
+                let al = unwrap_sf al in
                 Ok ((p, al) :: acc))
       >>= fun lst -> Ok (seq, lst)
 

--- a/src/app/type.ml
+++ b/src/app/type.ml
@@ -164,7 +164,7 @@ let () =
     let docv = "Filter out sequences" in
     let doc  = "Filter, do not include in the likelihood calculation, sequences \
                 where the highest number of mismatches is greater than the passed argument." in
-    Arg.(value & opt (some float) None & info ~doc ~docv ["filter-matches"])
+    Arg.(value & opt (some int) None & info ~doc ~docv ["filter-matches"])
   in
   let do_not_normalize_flag =
     let docv = "Do not normalize the likelihoods" in

--- a/src/lib/alignment.ml
+++ b/src/lib/alignment.ml
@@ -48,21 +48,63 @@ module NodeMapQueue = struct
 
   end
 
-(* A semi_group? *)
-module type Alignment_group = sig
-  type a
-  val zero : a
-  val incr : pos:int -> v:int -> a -> a
-  val merge : a -> a -> a
-  val acc_to_string : a -> string
+module Segment = struct
 
-  (* For now, these are separated and 'a' is not a parameter of a stop type.
-     This allows the algorithm to check when to stop. *)
-  type stop
-  type stop_arg
-  val init_stop : unit -> stop
-  val update : stop -> a -> stop
-  val stop : stop_arg -> stop -> bool
+  type t =
+    { matches     : int
+    ; mismatches  : int
+    }
+
+  let zero = { matches = 0; mismatches = 0 }
+  let mismatches n = { matches = 0; mismatches = n }
+  let matches    n = { matches = n; mismatches = 0 }
+
+  let matched ?(n=1) m = { m with matches = m.matches + n }
+  let mismatched ?(n=1) m = { m with mismatches = m.mismatches + n }
+  let to_string m =
+    sprintf "{m : %d, ms: %d}" m.matches m.mismatches
+
+end (* Segment *)
+
+let alignment_over_segments ~segment1 ~offset1 ~segment2 ~offset2 =
+  let open Segment in
+  let l1 = String.length segment1 in
+  let l2 = String.length segment2 in
+  let rec loop i m =
+    let i1 = i + offset1 in
+    let i2 = i + offset2 in
+    if i1 >= l1 then
+      if i2 >= l2 then
+        `Both m
+      else
+        `First (m, i2)
+    else if i2 >= l2 then
+      `Second (m, i1)
+    else
+      let c1 = String.get_exn segment1 i1 in
+      let c2 = String.get_exn segment2 i2 in
+      if c1 = c2 then
+        loop (i + 1) (matched m)
+      else
+        loop (i + 1) (mismatched m)
+  in
+  loop 0 zero
+
+module type Alignment_config = sig
+
+  type a                (* Value to track for each allele /edge. *)
+  type stop             (* Global (across graph) value to track. *)
+  type stop_parameter   (* Parameter to stopping logic. *)
+
+  val zero : a
+  val to_string : a -> string
+
+  val stop_init : stop
+  val stop_to_string : stop -> string
+
+  val from_alignment : position:int -> Segment.t -> a
+
+  val update : stop_parameter -> stop -> current:a -> aligned:a -> (a * stop) option
 
 end
 
@@ -74,36 +116,17 @@ let search_pos_edge_lst_to_string aindex l =
   |> String.concat ~sep:";"
   |> sprintf "[%s]"
 
-module Align (Ag : Alignment_group) = struct
-
-  let align ~s1 ~o1 ~s2 ~o2 =
-    let l1 = String.length s1 in
-    let l2 = String.length s2 in
-    let rec loop i m =
-      let i1 = i + o1 in
-      let i2 = i + o2 in
-      if i1 >= l1 then
-        if i2 >= l2 then
-          `Both m
-        else
-          `First (m, i2)
-      else if i2 >= l2 then
-        `Second (m, i1)
-      else
-        let c1 = String.get_exn s1 i1 in
-        let c2 = String.get_exn s2 i2 in
-        loop (i + 1) (if c1 = c2 then m else Ag.incr ~pos:i1 ~v:1 m)
-    in
-    loop 0 Ag.zero
+module Align (Ag : Alignment_config) = struct
 
   let align_against s =
+    let align = alignment_over_segments ~segment1:s in
     fun ~search_pos ~node_seq ~node_offset ->
-      match align ~s1:s ~o1:search_pos ~s2:node_seq ~o2:node_offset with
+      match align ~offset1:search_pos ~segment2:node_seq ~offset2:node_offset with
       | `Both m
       | `First (m, _)   -> `Finished m      (* end of the search string *)
       | `Second (m, so) -> `GoOn (m, so)
 
-  let compute gt stop_arg search_seq pos =
+  let compute gt stop_parameter search_seq pos =
     let open Ref_graph in
     let open Nodes in
     let open Index in
@@ -116,63 +139,36 @@ module Align (Ag : Alignment_group) = struct
 
     (* State and updating. *)
     let mis_map = Alleles.Map.make gt.aindex Ag.zero in
-    let stop_ref = ref (Ag.init_stop ()) in
-    let ag_incr_track_stop ~pos ~v current =
-      let n = Ag.incr ~pos ~v current in
-      stop_ref := Ag.update !stop_ref n;
-      n
-    in
-    let ag_merge_track_stop n1 n2 =
-      let n = Ag.merge n1 n2 in
-      stop_ref := Ag.update !stop_ref n;
-      n
-    in
-    let assign ?node edge_set ~position mismatches =
+
+    let ag_update = Ag.update stop_parameter in
+    let assign ?node edge_set ~search_pos stop sa =
+      let aligned = Ag.from_alignment ~position:search_pos sa in
       if !debug_ref then
-        eprintf "Assigning %d to %s because of:%s\n%!" mismatches
+        eprintf "Assigning %s at %d -> %s to %s because of:%s\n%!"
+          (Segment.to_string sa)
+          search_pos
+          (Ag.to_string aligned)
           (Alleles.Set.to_human_readable ~max_length:20000 gt.aindex edge_set)
           (Option.value ~default:"---" (Option.map node ~f:Nodes.vertex_name));
-      Alleles.Map.update_from edge_set mis_map (ag_incr_track_stop ~pos ~v:mismatches);
-      Ag.stop stop_arg !stop_ref
-    in
-    let merge_assign ?node edge_set ag =
-      if !debug_ref then
-        eprintf "Merging %s to %s because of:%s\n%!" (Ag.acc_to_string ag)
-          (Alleles.Set.to_human_readable ~max_length:20000 gt.aindex edge_set)
-          (Option.value ~default:"---" (Option.map node ~f:Nodes.vertex_name));
-      Alleles.Map.update_from edge_set mis_map (ag_merge_track_stop ag);
-      Ag.stop stop_arg !stop_ref
+
+      Alleles.Map.update_from_and_fold edge_set mis_map ~init:(Some stop)
+        ~f:(fun stop_opt current ->
+              match stop_opt with
+              | None      -> current, None
+              | Some stop ->
+                  match ag_update ~current ~aligned stop with
+                  | None        -> current, None
+                  | Some (n, s) -> n, (Some s))
+        (* NOTE: One could move the optionality into an 'update_from_and_fold_opt'
+          if the underlying fold (in Alleles.Map) had the appropriate
+          short-circuiting logic. I think that would be cleaner, because then we
+          would stop updating asap, and avoid this double option matching. In
+          practice, computing likelihood probably isn't that taxing, so we'll
+          fold over the entire edge set. *)
     in
 
-    (* Match a sequence, and add successor nodes to the queue for processing.
-       Return an optional current queue, where None mean stop.  *)
-    let rec match_and_add_succ queue_opt ((node, splst) as ns) =
-      Option.bind queue_opt ~f:(fun queue ->
-        match node with
-        | S _               -> invalid_argf "How did a Start get here %s!" (vertex_name node)
-        | B _               -> Some (add_successors queue ns)
-        | E _               ->
-            let stop =
-              List.fold_left splst ~init:false ~f:(fun stop (search_pos, edge) ->
-                stop || assign ~node edge ~position:search_pos (search_str_length - search_pos))
-            in
-            if stop then None else Some queue
-        | N (_p, node_seq)  ->
-            let nsplst, stop =
-              List.fold_left splst ~init:([], false)
-                ~f:(fun (acc, stopa) (search_pos, edge) ->
-                    match nmas ~search_pos ~node_seq ~node_offset:0 with
-                    | `Finished local_mismatches            ->
-                        let stop = merge_assign ~node edge local_mismatches in
-                        (acc, stopa || stop)
-                    | `GoOn (local_mismatches, search_pos)  ->
-                        let stop = merge_assign ~node edge local_mismatches in
-                        (search_pos, edge) :: acc, stopa || stop)
-            in
-            if stop then None else
-              match nsplst with
-              | [] -> Some queue
-              | _  -> Some (add_successors queue (node, nsplst)))
+    let rec add_successors queue (node, splst) =
+      G.fold_succ_e (add_edge_node splst) gt.g node queue
     and add_edge_node splst (_, edge, node) queue =
       let nsplst =
         List.filter_map splst ~f:(fun (sp, ep) ->
@@ -186,107 +182,135 @@ module Align (Ag : Alignment_group) = struct
           (search_pos_edge_lst_to_string gt.aindex nsplst)
       end;
       NodeMapQueue.add_to_queue queue node nsplst
-    and add_successors queue (node, splst) =
-      G.fold_succ_e (add_edge_node splst) gt.g node queue
+    (* Match a sequence, and add successor nodes to the queue for processing.
+       XXX Return an optional current queue, where None mean stop.  *)
+    and match_and_add_succ state_opt ((node, splst) as ns) =
+      Option.bind state_opt ~f:(fun (stop, queue) ->
+        match node with
+        | S _               -> invalid_argf "How did a Start get here %s!" (vertex_name node)
+        | B _               -> Some (stop, add_successors queue ns)
+        | E _               ->
+            List.fold_left splst ~init:(Some stop) ~f:(fun stop_opt (search_pos, edge) ->
+              Option.bind stop_opt ~f:(fun stop ->
+                let sa = Segment.mismatches (search_str_length - search_pos) in
+                assign ~node edge ~search_pos stop sa))
+            |> Option.map ~f:(fun s -> s, queue)
+
+        | N (_p, node_seq)  ->
+            List.fold_left splst ~init:(Some (stop, [])) ~f:(fun stop_opt (search_pos, edge) ->
+              Option.bind stop_opt ~f:(fun (stop, acc) ->
+                match nmas ~search_pos ~node_seq ~node_offset:0 with
+                | `Finished local_mismatches            ->
+                    assign ~node edge ~search_pos stop local_mismatches
+                    |> Option.map ~f:(fun s -> s, acc)
+                | `GoOn (local_mismatches, search_pos)  ->
+                    assign ~node edge ~search_pos stop local_mismatches
+                    |> Option.map ~f:(fun s -> s, (search_pos, edge) :: acc)))
+            |> Option.map ~f:(fun (s, acc) ->
+                match acc with
+                | [] -> (s, queue)
+                | _  -> (s, add_successors queue (node, acc))))
     in
-    let rec assign_loop q =
+    let rec assign_loop (stop, q) =
       if NodeMapQueue.is_empty q then
         `Finished mis_map
       else
         let nq, elst = NodeMapQueue.at_min_position q in
-        match List.fold_left elst ~init:(Some nq) ~f:match_and_add_succ with
-        | Some q -> assign_loop q
-        | None   -> `Stopped mis_map
+        match List.fold_left elst ~init:(Some (stop, nq)) ~f:match_and_add_succ with
+        | Some sq -> assign_loop sq
+        | None    -> `Stopped mis_map
     in
-    Ref_graph.adjacents_at gt ~pos >>= (fun (edge_node_set, seen_alleles, _) ->
+    Ref_graph.adjacents_at gt ~pos >>= begin fun (edge_node_set, seen_alleles, _) ->
       (* TODO. For now assume that everything that isn't seen has a full mismatch,
         this isn't strictly true since the Start of that allele could be within
         the range of the search str.
         - One approach would be to add the other starts, to the adjacents results.
 
-        This is also a weird case where we may stop aligning because of the
-        alleles that we haven't seen. Should we communicate this explicitly to
-        the 'Ag' logic? At least, we're communicating this condition via the
-        `Stopped | `Finished distinction.
         *)
-      let stop =
-        let not_seen = Alleles.Set.complement gt.aindex seen_alleles in
-        (* The assign is a no-op on an empty set but for readability, adding the if check. *)
-        if not (Alleles.Set.is_empty not_seen) then
-          assign not_seen ~position:0 search_str_length
-        else
-          false
-      in
-      if stop then Ok (`Stopped mis_map) else
-        let startq_opt =
-          EdgeNodeSet.fold edge_node_set ~init:(Some NodeMapQueue.empty)
-            (* Since the adjacents aren't necessarily at pos we have extra
-              bookkeeping at the start of the recursion. *)
-            ~f:(fun (edge, node) queue_opt ->
-                  Option.bind queue_opt ~f:(fun queue ->
-                    match node with
-                    | S _              ->
-                        invalid_argf "Asked to compute mismatches at %s, not a sequence node"
-                          (vertex_name node)
-                    | E _              ->
-                        let stop = assign ~node edge ~position:0 search_str_length in
-                        if stop then None else Some queue
-                    | B (p, _)         ->
-                        let dist = p - pos in
-                        if dist <= 0 then
-                          Some (add_successors queue (node, [0, edge]))
-                        else if dist < search_str_length then begin
-                          let stop = assign ~node edge ~position:0 dist in
-                          if stop then None else Some (add_successors queue (node, [dist, edge]))
-                        end else begin
-                          let stop = assign ~node edge ~position:0 search_str_length in
-                          if stop then None else Some (queue (* Nothing left to match. *))
-                        end
-                    | N (p, node_seq)  ->
-                        let nmas_and_assign ~node_offset ~start_mismatches =
-                          let start_ag =
-                            if start_mismatches > 0 then
-                              Ag.incr ~pos:0 ~v:start_mismatches Ag.zero
-                            else
-                              Ag.zero
+      let not_seen = Alleles.Set.complement gt.aindex seen_alleles in
+      let mismatch_whole_read = Segment.mismatches search_str_length in
+      let assigned_not_seen = assign not_seen ~search_pos:0 Ag.stop_init mismatch_whole_read in
+      match assigned_not_seen with
+      | None ->
+          (* This is also a weird case where we may stop aligning because of the
+             alleles that we haven't seen. Should we communicate this explicitly to
+             the 'Ag' logic? At least, we're communicating this condition via the
+             `Stopped | `Finished distinction.  *)
+          Ok (`Stopped mis_map)
+      | Some stop ->
+          let startq_opt =
+            EdgeNodeSet.fold edge_node_set ~init:(Some (stop, NodeMapQueue.empty))
+              (* Since the adjacents aren't necessarily at pos we have extra
+                bookkeeping at the start of the recursion. *)
+              ~f:(fun (edge, node) state_opt ->
+                    Option.bind state_opt ~f:(fun (stop, queue) ->
+                      let assign_start = assign ~node edge ~search_pos:0 stop in
+                      match node with
+                      | S _              ->
+                          invalid_argf "Asked to compute mismatches at %s, not a sequence node"
+                            (vertex_name node)
+                      | E _              ->
+                          assign_start (Segment.mismatches search_str_length)
+                          |> Option.map ~f:(fun s -> (s, queue))
+                      | B (p, _)         ->
+                          let dist = p - pos in
+                          if dist <= 0 then
+                            Some (stop, add_successors queue (node, [0, edge]))
+                          else if dist < search_str_length then begin
+                            assign_start (Segment.mismatches dist)
+                            |> Option.map ~f:(fun s -> (s, add_successors queue (node, [dist, edge])))
+                          end else begin
+                            assign_start (Segment.mismatches search_str_length)
+                            |> Option.map ~f:(fun s -> (s, queue (* Nothing left to match. *)))
+                          end
+                      | N (p, node_seq)  ->
+                          let nmas_and_assign ~node_offset ~start_mismatches =
+                            match nmas ~search_pos:start_mismatches ~node_seq ~node_offset with
+                            | `Finished mismatches            ->
+                                assign_start (Segment.mismatched ~n:start_mismatches mismatches)
+                                |> Option.map ~f:(fun s -> (s, queue))
+                            | `GoOn (mismatches, search_pos)  ->
+                                assign_start (Segment.mismatched ~n:start_mismatches mismatches)
+                                |> Option.map ~f:(fun s -> (s, add_successors queue (node, [search_pos, edge])))
                           in
-                          match nmas ~search_pos:start_mismatches ~node_seq ~node_offset with
-                          | `Finished mismatches            ->
-                              let stop = merge_assign ~node edge (ag_merge_track_stop mismatches start_ag) in
-                              if stop then None else Some queue
-                          | `GoOn (mismatches, search_pos)  ->
-                              let stop = merge_assign ~node edge (ag_merge_track_stop mismatches start_ag) in
-                              if stop then None else Some (add_successors queue (node, [search_pos, edge]))
-                        in
-                        let dist = p - pos in
-                        if dist <= 0 then
-                          nmas_and_assign ~node_offset:(-dist) ~start_mismatches:0
-                        else if dist < search_str_length then
-                          nmas_and_assign ~node_offset:0 ~start_mismatches:dist
-                        else begin
-                          let stop = assign ~node edge ~position:0 search_str_length in
-                          if stop then None else Some queue
-                        end))
-        in
-        match startq_opt with
-        | None        -> Ok (`Stopped mis_map)
-        | Some startq -> Ok (assign_loop startq))
+                          let dist = p - pos in
+                          if dist <= 0 then
+                            nmas_and_assign ~node_offset:(-dist) ~start_mismatches:0
+                          else if dist < search_str_length then
+                            nmas_and_assign ~node_offset:0 ~start_mismatches:dist
+                          else begin
+                            assign_start (Segment.mismatches search_str_length)
+                            |> Option.map ~f:(fun s -> (s, queue))
+                          end))
+          in
+          match startq_opt with
+          | None        -> Ok (`Stopped mis_map)
+          | Some startq -> Ok (assign_loop startq)
+    end
 
 end (* Align *)
 
 module Mismatches = Align (struct
-  type a = int
-  let zero = 0
-  let incr ~pos ~v m = v + m
-  let merge m1 m2 = m1 + m2
-  let acc_to_string = sprintf "%d"
 
-  (* Stop when above a max *)
-  type stop = int
-  type stop_arg = int
-  let init_stop () = 0
-  let update = max
-  let stop arg state = state > arg
+  type a = int
+  type stop = float                   (* Current sum. *)
+  type stop_parameter = int * float   (* Number of edges, max mean. *)
+
+  let zero = 0
+  let to_string = sprintf "%d"
+
+  let stop_init = 0.
+  let stop_to_string = sprintf "sum %f"
+
+  let from_alignment ~position sa = sa.Segment.mismatches
+
+  let update (number_elements, max_mean) stop ~current ~aligned =
+    let newal = current + aligned in
+    let nstop = stop +. (float aligned) in
+    if nstop /. (float number_elements) > max_mean then
+      None
+    else
+      Some (newal, nstop)
 
 end)
 
@@ -294,19 +318,28 @@ let num_mismatches_against_seq = Mismatches.align_against
 let compute_mismatches = Mismatches.compute
 
 module PositionMismatches = Align (struct
+
   type a = (int * int) list
+  type stop = float                   (* Current sum. *)
+  type stop_parameter = int * float   (* Number of edges, max mean. *)
+
   let zero = []
-  let incr ~pos ~v m = (pos, v) :: m
-  let merge m1 m2 = List.sort ~cmp:compare (m1 @ m2)
-  let acc_to_string l =
+  let to_string l =
     List.map l ~f:(fun (p,m) -> sprintf "(%d,%d)" p m)
     |> String.concat ~sep:"; "
 
-  type stop = int
-  type stop_arg = int
-  let init_stop () = 0
-  let update s l = max s (List.length l)
-  let stop arg state = state > arg
+  let stop_init = 0.
+  let stop_to_string = sprintf "sum %f"
+
+  let from_alignment ~position sa = [position, sa.Segment.mismatches]
+
+  let update (number_elements, max_mean) stop ~current ~aligned =
+    let newal = current @ aligned in
+    let nstop = stop +. (float (List.length newal)) in
+    if nstop /. (float number_elements) > max_mean then
+      None
+    else
+      Some (newal, nstop)
 
 end)
 
@@ -331,7 +364,7 @@ let manual_mismatches gt search_seq pos =
       s allele >>= fun graph_seq ->
           Ok (nmas ~node_seq:graph_seq ~node_offset:0)
     else
-      Ok (`Finished n))
+      Ok (`Finished (Segment.mismatches n)))
 
 let to_weights lst =
   let flst = List.map ~f:float_of_int lst in

--- a/src/lib/alleles.ml
+++ b/src/lib/alleles.ml
@@ -255,8 +255,14 @@ module Map = struct
       m.(j) <- f (BitSet.is_set s j) m.(j)
     done
 
-  let update_from s m f =
+  let update_from s ~f m =
     Enum.iter (fun i -> m.(i) <- f m.(i)) (BitSet.enum s)
+
+  let update_from_and_fold s ~f ~init m =
+    Enum.fold (fun i acc ->         (* Accumulator in 2nd position. *)
+      let nm, nacc = f acc m.(i) in (* Use in 1st position ala fold_left. *)
+      m.(i) <- nm;
+      nacc) init (BitSet.enum s)
 
   let update2 ~source ~dest f =
     for i = 0 to Array.length source - 1 do

--- a/src/lib/alleles.mli
+++ b/src/lib/alleles.mli
@@ -129,9 +129,13 @@ module Map : sig
       they are in [set] is passed the first arg to [f]. *)
   val update_all : Set.t -> 'a t -> (bool -> 'a -> 'a) -> unit
 
-  (** [update_from set map f] apply [f] to all alleles in [map] that are
+  (** [update_from set f map] apply [f] to all alleles in [map] that are
       in [set]. *)
-  val update_from : Set.t -> 'a t -> ('a -> 'a) -> unit
+  val update_from : Set.t -> f:('a -> 'a) -> 'a t -> unit
+
+  (** [update_from_and_fold set f init map] updates and folds over the [set]
+      elements of [map].*)
+  val update_from_and_fold : Set.t -> f:('a -> 'b -> 'b * 'a) -> init:'a -> 'b t -> 'a
 
   val update_spec : index -> 'a t -> allele -> ('a -> 'a) -> unit
 

--- a/src/lib/path_inference.ml
+++ b/src/lib/path_inference.ml
@@ -12,8 +12,8 @@ let log_likelihood ?(alph_size=4) ?(er=0.01) ~len mismatches =
 let likelihood ?alph_size ?er ~len m =
   exp (log_likelihood ?alph_size ?er ~len m)
 
-let report_mismatches aindex mm =
-  printf "reporting mismatches\n";
+let report_mismatches state aindex mm =
+  printf "reporting %s mismatches\n" state;
   let () =
     Alleles.Map.values_assoc aindex mm
     |> List.sort ~cmp:(fun (i1,_) (i2,_) -> compare i1 i2)
@@ -24,53 +24,62 @@ let report_mismatches aindex mm =
   in
   printf "finished reporting mismatches\n%!"
 
-let one ?(verbose=false) ?(multi_pos=`Best) g idx seq =
-  let report mm =
-    if verbose then report_mismatches g.Ref_graph.aindex mm else ()
-  in
+let one ?(verbose=false) ?(multi_pos=`Best) ?early_stop g idx seq =
+  let report state mm = if verbose then report_mismatches state g.Ref_graph.aindex mm in
   (*let len = String.length seq in *)
   let to_float_map = Alleles.Map.map_wa ~f:float in
-  Index.lookup idx seq >>= function
-    | []      -> error "no index found!"
-    | h :: t  ->
-      Alignment.compute_mismatches g seq h >>= fun mm ->
-        report mm;
-        match t with
-        | [] -> Ok (to_float_map mm)
-        | tl ->
-            match multi_pos with
-            | `TakeFirst        -> Ok (to_float_map mm)
-            | `Average          ->
-                let n = 1 + List.length t in
-                let weight = 1. /. (float n) in
-                let lm = Alleles.Map.map_wa (to_float_map mm) ~f:(fun m -> m /. weight) in
-                let rec loop = function
-                  | []     -> Ok lm
-                  | p :: t ->
-                      Alignment.compute_mismatches g seq p >>= fun mm ->
-                          report mm;
-                          Alleles.Map.update2 mm lm (fun m c -> c +. weight *. (float m));
-                          loop t
-                in
-                loop tl
-            (* Find the best alignment, the one with the lowest number of
-               mismatches, over all indexed positions! *)
-            | `Best             ->
-                let current_best = Alleles.Map.fold_wa mm ~init:max_int ~f:min in
-                let rec loop b bm = function
-                  | []     -> Ok (to_float_map bm)
-                  | p :: t ->
-                      (* TODO: If this becomes a bottleneck, we can stop [compute_mismatches]
-                         early if the min mismatch > b *)
-                      Alignment.compute_mismatches g seq p >>= fun nbm ->
-                          report nbm;
-                          let nb = Alleles.Map.fold_wa nbm ~init:max_int ~f:min in
-                          if nb < b then
-                            loop nb nbm t
-                          else
-                            loop b bm t
-                in
-                loop current_best mm tl
+  let early_stop = Option.value early_stop ~default:(String.length seq) in
+  let rec across_positions error_msg = function
+    | []     -> error "%s" error_msg
+    | h :: t ->
+      Alignment.compute_mismatches g early_stop seq h >>= function
+        | `Stopped mm  ->
+            report "stopped" mm;
+            across_positions "stopped on previous indexed positions" t
+        | `Finished mm ->
+            report "finished" mm;
+            match t with
+            | [] -> Ok (to_float_map mm)
+            | tl ->
+                match multi_pos with
+                | `TakeFirst    -> Ok (to_float_map mm)
+                | `Average      ->
+                    let lm = to_float_map mm in
+                    let rec loop n = function
+                      | []     -> Ok lm
+                      | p :: t ->
+                          Alignment.compute_mismatches g early_stop seq p >>= function
+                            | `Stopped mm  ->
+                                report "stopped during averaging" mm;
+                                loop n t
+                            | `Finished mm ->
+                                report "finished during averaging" mm;
+                                (* Online mean update formula *)
+                                Alleles.Map.update2 ~source:mm ~dest:lm
+                                  (fun v m -> m +. n *. ((float v) -. m) /. (n +. 1.));
+                                loop (n +. 1.) t
+                    in
+                    loop 1.0 tl
+                | `Best ->
+                    let current_best = Alleles.Map.fold_wa mm ~init:max_int ~f:min in
+                    let rec loop b bm = function
+                      | []     -> Ok (to_float_map bm)
+                      | p :: t ->
+                          Alignment.compute_mismatches g early_stop seq p >>= function
+                            | `Stopped mm ->
+                                report "stopped during best search" mm;
+                                loop b bm t
+                            | `Finished mm ->
+                                report "finished during best search" mm;
+                                let nb = Alleles.Map.fold_wa mm ~init:max_int ~f:min in
+                                if nb < b then
+                                  loop nb mm t
+                                else
+                                  loop b bm t
+                    in
+                    loop current_best mm tl
+  in
+  Index.lookup idx seq >>= (across_positions "no index found!")
 
 let mx b amap =
   let n = Alleles.Map.cardinal amap in
@@ -79,12 +88,12 @@ let mx b amap =
 
 let yes _ = true
 
-let multiple_fold_lst ?verbose ?multi_pos ?filter g idx =
+let multiple_fold_lst ?verbose ?multi_pos ?filter ?early_stop g idx =
   let list_map = Alleles.Map.make g.Ref_graph.aindex [] in
   let filter = match filter with | None -> yes | Some n -> mx n in
   let update v l = v :: l in
   let fold amap seq =
-    one ?verbose ?multi_pos g idx seq >>= fun m ->
+    one ?verbose ?multi_pos ?early_stop g idx seq >>= fun m ->
       if filter m then begin
         Alleles.Map.update2 ~source:m ~dest:amap update;
         match verbose with | Some true -> printf "passed filter\n" | _ -> ()
@@ -95,7 +104,7 @@ let multiple_fold_lst ?verbose ?multi_pos ?filter g idx =
   in
   list_map, fold
 
-let multiple_fold ?verbose ?multi_pos ?as_ ?filter ?er g idx =
+let multiple_fold ?verbose ?multi_pos ?as_ ?filter ?early_stop ?er g idx =
   let zero_map = Alleles.Map.make g.Ref_graph.aindex 0. in
   let one_map = Alleles.Map.make g.Ref_graph.aindex 1. in
   let filter = match filter with | None -> yes | Some n -> mx n in
@@ -108,7 +117,7 @@ let multiple_fold ?verbose ?multi_pos ?as_ ?filter ?er g idx =
   in
   let fold amap seq =
     let len = String.length seq in
-    one ?verbose ?multi_pos g idx seq >>= fun m ->
+    one ?verbose ?multi_pos ?early_stop g idx seq >>= fun m ->
       if filter m then begin
         Alleles.Map.update2 ~source:m ~dest:amap (update ?er ~len);
         match verbose with | Some true -> printf "passed filter\n" | _ -> ()

--- a/src/lib/ref_graph.ml
+++ b/src/lib/ref_graph.ml
@@ -109,6 +109,9 @@ type t =
   ; offset  : int
   }
 
+let number_of_alleles g =
+  A.Map.cardinal g.bounds
+
 (** Output **)
 
 (* TODO:


### PR DESCRIPTION
This PR doesn't improve the performance spectacularly. I think the allocation overhead goes up at the same time to compensate the short-circuiting logic. I'll save the performance optimization to a later date, since we'll probably use a different likelihood calculation anyway.