### PR TITLE
Improve allele selection in graph

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SETUP_PACKAGE_NAMES=ocamlfind ocamlbuild ppx_deriving nonstd sosa ocamlgraph cmd
 TOOLS=mhc2gpdf type
 TESTS=test_parsing round_trip same_alignments_test check_multiple adjacents benchmark_k
 
-.PHONY: default setup clean build
+.PHONY: default setup clean build tools tests
 
 default: build
 

--- a/src/app/common_options.ml
+++ b/src/app/common_options.ml
@@ -41,10 +41,22 @@ let allele_arg =
              By default the behavior is to add [num_alt] alleles (in \
              alphabetical order) to the graph. Use this option to construct \
              a graph with specific alleles (ex. A*01:02). Specify multiple \
-             alleles with multiple arguments. This flag will override \
-             [num_alt]."
+             alleles with multiple arguments. This argument will override the \
+             [num_alt] flag but may be used in tandem with the allele-regex \
+             arguments."
   in
   Arg.(value & opt_all string [] & info ~doc ~docv ["a"; "allele"])
+
+let allele_regex_arg =
+  let docv = "allele name regex" in
+  let doc = "Specify specfic alternate alleles to add to the graph via a regex.\
+             This option is similar to allele, but lets the user specify a class
+             (specifically a pattern) of alleles to include in the graph, \
+             without having to add them individually via the allele option. \
+             This argument will override [num_alt] but may be used in tandem \
+             with allele flag."
+  in
+  Arg.(value & opt_all string [] & info ~doc ~docv ["ar"; "allele-regex"])
 
 let no_cache_flag =
   let doc =
@@ -61,18 +73,22 @@ let do_not_join_same_sequence_paths_flag =
   in
   Arg.(value & flag & info ~doc ["do-not-join-same-sequence-paths"])
 
-let to_filename_and_graph_args alignment_file num_alt_to_add allele_list join_same_sequence =
+let to_filename_and_graph_args alignment_file num_alt_to_add allele_list
+  allele_regex_list join_same_sequence =
   let open Ref_graph in
   let base = Filename.basename alignment_file |> Filename.chop_extension in
   let option_based_fname, which =
-    match allele_list with
-    | []  ->
+    match allele_list, allele_regex_list with
+    | [], [] ->
         begin
           match num_alt_to_add with
-          | None   -> sprintf "%s_%b_all" base join_same_sequence, None
-          | Some n -> sprintf "%s_%b_%d" base join_same_sequence n, (Some (NumberOfAlts n))
+          | None      -> sprintf "%s_%b_all" base join_same_sequence
+                         , None
+          | Some n    -> sprintf "%s_%b_%d" base join_same_sequence n
+                         , (Some (NumberOfAlts n))
         end
-    | lst -> sprintf "%s_spec_%d" base (Hashtbl.hash lst), (Some (SpecificAlleles lst))
+    | specific, regex -> sprintf "%s_spec_%d" base (Hashtbl.hash (specific, regex))
+                         , (Some (Alleles { specific; regex }))
   in
   option_based_fname, { Cache.alignment_file; Cache.which ; Cache.join_same_sequence }
 

--- a/src/app/common_options.ml
+++ b/src/app/common_options.ml
@@ -54,7 +54,9 @@ let allele_regex_arg =
              (specifically a pattern) of alleles to include in the graph, \
              without having to add them individually via the allele option. \
              This argument will override [num_alt] but may be used in tandem \
-             with allele flag."
+             with allele flag. The regex format is POSIX, and the '*' used in \
+             HLA allele names must be properly escaped from the command line:
+             ex. -ar \"A\\*02:03\""
   in
   Arg.(value & opt_all string [] & info ~doc ~docv ["ar"; "allele-regex"])
 

--- a/src/app/mhc2gpdf.ml
+++ b/src/app/mhc2gpdf.ml
@@ -3,13 +3,14 @@ open Util
 open Common_options
 
 let construct ofile alignment_file num_alt_to_add allele_list allele_regex_list
-      notshort no_pdf no_open skip_disk_cache max_edge_char_length not_human_edges
-      not_join_same_seq not_compress_edges not_compress_start not_insert_newlines =
+      remove_reference notshort no_pdf no_open skip_disk_cache max_edge_char_length
+      not_human_edges not_join_same_seq not_compress_edges not_compress_start
+      not_insert_newlines =
   let open Ref_graph in
   let open Cache in
   let option_based_fname, cargs =
     to_filename_and_graph_args alignment_file num_alt_to_add allele_list
-      allele_regex_list (not not_join_same_seq)
+      allele_regex_list (not not_join_same_seq) remove_reference
   in
   let ofile = Option.value ofile ~default:option_based_fname in
   let short = not notshort in
@@ -100,6 +101,7 @@ let () =
             $ num_alt_arg
             $ allele_arg
             $ allele_regex_arg
+            $ remove_reference_flag
             $ not_short_flag $ no_pdf_flag $ no_open_flag
             $ no_cache_flag
             $ max_edge_char_length_flag

--- a/src/app/mhc2gpdf.ml
+++ b/src/app/mhc2gpdf.ml
@@ -2,14 +2,14 @@
 open Util
 open Common_options
 
-let construct ofile alignment_file num_alt_to_add allele_list notshort no_pdf
-      no_open skip_disk_cache max_edge_char_length not_human_edges
+let construct ofile alignment_file num_alt_to_add allele_list allele_regex_list
+      notshort no_pdf no_open skip_disk_cache max_edge_char_length not_human_edges
       not_join_same_seq not_compress_edges not_compress_start not_insert_newlines =
   let open Ref_graph in
   let open Cache in
   let option_based_fname, cargs =
     to_filename_and_graph_args alignment_file num_alt_to_add allele_list
-      (not not_join_same_seq)
+      allele_regex_list (not not_join_same_seq)
   in
   let ofile = Option.value ofile ~default:option_based_fname in
   let short = not notshort in
@@ -97,7 +97,9 @@ let () =
     in
     Term.(const construct
             $ output_fname_arg $ file_arg
-            $ num_alt_arg $ allele_arg
+            $ num_alt_arg
+            $ allele_arg
+            $ allele_regex_arg
             $ not_short_flag $ no_pdf_flag $ no_open_flag
             $ no_cache_flag
             $ max_edge_char_length_flag

--- a/src/app/type.ml
+++ b/src/app/type.ml
@@ -70,6 +70,7 @@ let report_likelihood g amap do_not_bucket =
       |> output_values_assoc g.aindex
 
 let type_ verbose alignment_file num_alt_to_add allele_list allele_regex_list
+  remove_reference
   k skip_disk_cache
   fastq_file not_join_same_seq number_of_reads print_top multi_pos as_stat
   filter do_not_normalize do_not_bucket likelihood_error =
@@ -77,7 +78,7 @@ let type_ verbose alignment_file num_alt_to_add allele_list allele_regex_list
   let open Ref_graph in
   let option_based_fname, g =
     Common_options.to_filename_and_graph_args alignment_file num_alt_to_add
-      allele_list allele_regex_list (not not_join_same_seq)
+      allele_list allele_regex_list (not not_join_same_seq) remove_reference
   in
   let g, idx = Cache.graph_and_two_index ~skip_disk_cache { k ; g } in
   let early_stop = Option.map filter ~f:(fun n -> Ref_graph.number_of_alleles g, float n) in
@@ -213,7 +214,8 @@ let () =
     in
     Term.(const type_
             $ verbose_flag
-            $ file_arg $ num_alt_arg $ allele_arg $ allele_regex_arg
+            $ file_arg
+            $ num_alt_arg $ allele_arg $ allele_regex_arg $ remove_reference_flag
             $ kmer_size_arg $ no_cache_flag
             $ fastq_file_arg
             $ do_not_join_same_sequence_paths_flag

--- a/src/app/type.ml
+++ b/src/app/type.ml
@@ -69,14 +69,15 @@ let report_likelihood g amap do_not_bucket =
       |> fun l -> List.take l n
       |> output_values_assoc g.aindex
 
-let type_ verbose alignment_file num_alt_to_add allele_list k skip_disk_cache
+let type_ verbose alignment_file num_alt_to_add allele_list allele_regex_list
+  k skip_disk_cache
   fastq_file not_join_same_seq number_of_reads print_top multi_pos as_stat
   filter do_not_normalize do_not_bucket likelihood_error =
   let open Cache in
   let open Ref_graph in
   let option_based_fname, g =
     Common_options.to_filename_and_graph_args alignment_file num_alt_to_add
-      allele_list (not not_join_same_seq)
+      allele_list allele_regex_list (not not_join_same_seq)
   in
   let g, idx = Cache.graph_and_two_index ~skip_disk_cache { k ; g } in
   let early_stop = Option.map filter ~f:(fun n -> Ref_graph.number_of_alleles g, float n) in
@@ -212,7 +213,8 @@ let () =
     in
     Term.(const type_
             $ verbose_flag
-            $ file_arg $ num_alt_arg $ allele_arg $ kmer_size_arg $ no_cache_flag
+            $ file_arg $ num_alt_arg $ allele_arg $ allele_regex_arg
+            $ kmer_size_arg $ no_cache_flag
             $ fastq_file_arg
             $ do_not_join_same_sequence_paths_flag
             $ num_reads_arg

--- a/src/lib/cache.ml
+++ b/src/lib/cache.ml
@@ -50,4 +50,3 @@ let graph_and_two_index_no_cache {k; g} =
 let graph_and_two_index =
   let dir = Filename.concat (Sys.getcwd ()) index_cache_dir in
   disk_memoize ~dir index_args_to_string graph_and_two_index_no_cache
-

--- a/src/lib/cache.ml
+++ b/src/lib/cache.ml
@@ -5,28 +5,32 @@ type graph_args =
   { alignment_file      : string       (* this is really a path, basename below *)
   ; which               : Ref_graph.construct_which_args option
   ; join_same_sequence  : bool
+  ; remove_reference    : bool
   }
 
-let graph_arg ?n ?(join_same_sequence=true) ~file () =
+let graph_arg ?n ?(join_same_sequence=true) ?(remove_reference=false) ~file () =
   { alignment_file = file
   ; which = n
   ; join_same_sequence
+  ; remove_reference
   }
 
-let graph_args_to_string { alignment_file; which; join_same_sequence } =
-  sprintf "%s_%s_%b"
+let graph_args_to_string { alignment_file; which; join_same_sequence; remove_reference } =
+  sprintf "%s_%s_%b_%b"
     (Filename.basename alignment_file)
     (match which with
       | None -> "All"
       | Some w -> Ref_graph.construct_which_args_to_string w)
     join_same_sequence
+    remove_reference
 
 let dir = ".cache"
 
 let graph_cache_dir = Filename.concat dir "graphs"
 
-let graph_no_cache { alignment_file; which; join_same_sequence } =
-  Ref_graph.construct_from_file ~join_same_sequence ?which alignment_file
+let graph_no_cache { alignment_file; which; join_same_sequence; remove_reference } =
+  Ref_graph.construct_from_file ~join_same_sequence ~remove_reference ?which
+    alignment_file
 
 let graph =
   let dir = Filename.concat (Sys.getcwd ()) graph_cache_dir in

--- a/src/lib/ref_graph.ml
+++ b/src/lib/ref_graph.ml
@@ -716,7 +716,7 @@ let create_by_position g aindex bounds =
 
 module JoinSameSequencePaths = struct
 
-  (* Alignment and sequence pair set used as queue *)
+  (* Alignment and sequence pair, set used as queue *)
   module Apsq =
     Set.Make(struct
       type t = alignment_position * sequence
@@ -923,7 +923,7 @@ let construct_which_args_to_string = function
                                         |> Digest.to_hex
                                         |> sprintf "R%s"
 
-let construct_from_parsed ?which ?(join_same_sequence=true) r =
+let construct_from_parsed ?which ?(join_same_sequence=true) ?(remove_reference=false) r =
   let open Mas_parser in
   let { reference; ref_elems; alt_elems} = r in
   let alt_elems = List.sort ~cmp:(fun (n1, _) (n2, _) -> A.compare n1 n2) alt_elems in
@@ -967,6 +967,12 @@ let construct_from_parsed ?which ?(join_same_sequence=true) r =
   in
   if join_same_sequence then
     JoinSameSequencePaths.do_it g aindex bounds; (* mutates 'g' *)
+  let g, aindex, bounds =
+    if remove_reference then
+      failwith "Not implemented!"
+    else
+      g, aindex, bounds
+  in
   let offset = fst (range_pr bounds) in
   let posarr = create_by_position g aindex bounds in
   { g
@@ -976,8 +982,8 @@ let construct_from_parsed ?which ?(join_same_sequence=true) r =
   ; posarr
   }
 
-let construct_from_file ~join_same_sequence ?which file =
-  construct_from_parsed ~join_same_sequence ?which (Mas_parser.from_file file)
+let construct_from_file ~join_same_sequence ~remove_reference ?which file =
+  construct_from_parsed ~join_same_sequence ~remove_reference ?which (Mas_parser.from_file file)
 
 (* More powerful accessors *)
 let all_bounds { aindex; bounds; _} allele =

--- a/src/lib/ref_graph.ml
+++ b/src/lib/ref_graph.ml
@@ -1,6 +1,7 @@
 
 open Util
 open Graph
+open MoreLabels
 module A = Alleles
 
 (* TODO:
@@ -586,60 +587,64 @@ let add_non_ref g reference aindex (first_start, last_end, end_to_next_start_ass
   in
   start_loop [] alt_lst
 
-module FoldAtSamePosition = struct
+(* TODO: use a real heap/pq ds?
+  - The one in Graph doesn't allow you to control not putting in duplicates
+*)
+module NodeQueue = struct
 
-  (* TODO: use a real heap/pq ds?
-    - The one in Graph doesn't allow you to control not putting in duplicates
-  *)
-  module NodeQueue =
-    Set.Make(struct
+  include Set.Make(struct
       type t = Nodes.t
       let compare = Nodes.compare_by_position_first
     end)
 
-  let add_successors g = G.fold_succ NodeQueue.add g
-
-  let with_start_nodes g aindex bounds =
-    let open Nodes in
-    Alleles.Map.fold aindex bounds ~init:NodeQueue.empty
-      ~f:(fun q sep_lst allele ->
-            List.fold_left sep_lst ~init:q
-              ~f:(fun q sep ->
-                    NodeQueue.add (S (fst sep.start, allele)) q))
-
-  let after_start_nodes g aindex bounds =
-    let open Nodes in
-    Alleles.Map.fold aindex bounds ~init:NodeQueue.empty
-      ~f:(fun q sep_lst allele ->
-            List.fold_left sep_lst ~init:q
-              ~f:(fun q sep ->
-                    add_successors g (S (fst sep.start, allele)) q))
+  let add_successors g = G.fold_succ add g
 
   let at_min_position q =
     let rec loop p q acc =
-      if NodeQueue.is_empty q then
+      if is_empty q then
         q, acc
       else
-        let me = NodeQueue.min_elt q in
+        let me = min_elt q in
         match acc with
-        | [] -> loop (Nodes.position me) (NodeQueue.remove me q) [me]
+        | [] -> loop (Nodes.position me) (remove me q) [me]
         | _  -> if Nodes.position me = p then
-                  loop p (NodeQueue.remove me q) (me :: acc)
+                  loop p (remove me q) (me :: acc)
                 else
                   q, acc
     in
     loop min_int q []
 
+end
+
+let node_queue_with_start_nodes aindex bounds =
+  let open Nodes in
+  A.Map.fold aindex bounds ~init:NodeQueue.empty
+    ~f:(fun q sep_lst allele ->
+          List.fold_left sep_lst ~init:q
+            ~f:(fun q sep ->
+                  NodeQueue.add (S (fst sep.start, allele)) q))
+
+module FoldAtSamePosition = struct
+
+  let after_start_nodes g aindex bounds =
+    let open Nodes in
+    A.Map.fold aindex bounds ~init:NodeQueue.empty
+      ~f:(fun q sep_lst allele ->
+            List.fold_left sep_lst ~init:q
+              ~f:(fun q sep ->
+                    NodeQueue.add_successors g (S (fst sep.start, allele)) q))
+
   let step g q =
-    let without_old, amp = at_min_position q in
+    let without_old, amp = NodeQueue.at_min_position q in
     let withnew =
-      List.fold_left amp ~init:without_old ~f:(fun q n -> add_successors g n q)
+      List.fold_left amp ~init:without_old
+        ~f:(fun q n -> NodeQueue.add_successors g n q)
     in
     withnew, amp
 
   let fold_from g q ~f ~init =
     let rec loop a q =
-      if q = NodeQueue.empty then
+      if NodeQueue.is_empty q then
         a
       else
         let nq, amp = step g q in
@@ -652,12 +657,12 @@ module FoldAtSamePosition = struct
     fold_from g (after_start_nodes g aindex bounds) ~f ~init
 
   let f g aindex bounds ~f ~init =
-    fold_from g (with_start_nodes g aindex bounds) ~f ~init
+    fold_from g (node_queue_with_start_nodes aindex bounds) ~f ~init
 
 end (* FoldAtSamePosition *)
 
 let range_pr bounds =
-  Alleles.Map.fold_wa bounds ~init:(max_int, min_int)
+  A.Map.fold_wa bounds ~init:(max_int, min_int)
     ~f:(fun p sep_lst ->
           List.fold_left sep_lst ~init:p ~f:(fun (st, en) sep ->
             (min st (fst sep.start)), (max en sep.end_)))
@@ -763,7 +768,7 @@ module JoinSameSequencePaths = struct
   let after_starts g aindex bounds =
     let open Nodes in
     let add_successors = G.fold_succ (add_node_successors_only g) g in
-    Alleles.Map.fold aindex bounds ~init:Apsq.empty
+    A.Map.fold aindex bounds ~init:Apsq.empty
       ~f:(fun q sep_lst allele ->
             List.fold_left sep_lst ~init:q
               ~f:(fun q sep ->
@@ -777,7 +782,7 @@ module JoinSameSequencePaths = struct
       try
         let ecur = G.find_edge g pv nv in
         let into = G.E.label ecur in
-        Alleles.Set.unite ~into e;
+        A.Set.unite ~into e;
       with Not_found ->
           G.add_edge_e g (G.E.create pv e nv)
     in
@@ -908,6 +913,63 @@ module JoinSameSequencePaths = struct
 
 end (* JoinSameSequencePaths *)
 
+module RemoveSequence = struct
+
+  let do_it seq g aindex bounds =
+    let open Nodes in
+    let naindex =
+      A.to_alleles aindex
+      |> List.filter ~f:((<>) seq)
+      |> A.index
+    in
+    let nbounds = A.Map.init naindex (A.Map.get aindex bounds) in
+    let newe oe =
+      let ne = A.Set.init naindex in
+      A.Set.iter aindex (fun a -> if a <> seq then A.Set.set naindex ne a) oe;
+      ne
+    in
+    (* As is the norm, new_graph is mutated. *)
+    let new_graph = G.create ~size:(A.Map.cardinal nbounds) () in
+    let rec loop q =
+      if NodeQueue.is_empty q then
+        ()
+      else
+        let nq, me = NodeQueue.at_min_position q in
+        List.fold_left me ~init:nq ~f:(fun queue node ->
+          let nq = G.fold_succ_e (fun (p, e, sn) queue ->
+            let ne = newe e in
+            if A.Set.is_empty ne then
+              queue
+            else begin
+              match sn with
+              | S _ -> invalid_argf "pointing back at a start %s while remove %s"
+                          (vertex_name sn) seq
+              | E _ -> G.add_vertex new_graph sn;
+                       G.add_edge_e new_graph (p, ne, sn);
+                       queue
+              | B _
+              | N _ -> G.add_vertex new_graph sn;
+                       G.add_edge_e new_graph (p, ne, sn);
+                       NodeQueue.add sn queue
+            end) g node queue
+          in
+          nq)
+        |> loop
+    in
+    let start_queue =
+      A.Map.fold naindex nbounds ~init:NodeQueue.empty
+        ~f:(fun q sep_lst allele ->
+              List.fold_left sep_lst ~init:q
+                ~f:(fun q sep ->
+                      let start_node = S (fst sep.start, allele) in
+                      G.add_vertex new_graph start_node;
+                      NodeQueue.add start_node q))
+    in
+    loop start_queue;
+    new_graph, naindex, nbounds
+
+end (* RemoveSequence *)
+
 type construct_which_args =
   | NumberOfAlts of int
   | Alleles of { specific : string list
@@ -969,7 +1031,7 @@ let construct_from_parsed ?which ?(join_same_sequence=true) ?(remove_reference=f
     JoinSameSequencePaths.do_it g aindex bounds; (* mutates 'g' *)
   let g, aindex, bounds =
     if remove_reference then
-      failwith "Not implemented!"
+      RemoveSequence.do_it reference g aindex bounds
     else
       g, aindex, bounds
   in
@@ -987,7 +1049,7 @@ let construct_from_file ~join_same_sequence ~remove_reference ?which file =
 
 (* More powerful accessors *)
 let all_bounds { aindex; bounds; _} allele =
-  Alleles.Map.get aindex bounds allele
+  A.Map.get aindex bounds allele
 
 let find_bound g allele ~pos =
   all_bounds g allele
@@ -1031,7 +1093,7 @@ let find_node_at ?allele ?ongap ~pos { g; aindex; offset; posarr; _} =
         let is_along_allele node =
           try
             G.fold_pred_e (fun (_, e, _) _b ->
-              if Alleles.Set.is_set aindex e a then
+              if A.Set.is_set aindex e a then
                 raise M.Found else false) g node false
           with M.Found ->
             true
@@ -1152,11 +1214,11 @@ let sequence ?start ?stop ({g; aindex; bounds } as gt) allele =
       |> fun s -> Ok s
 
 let alleles_with_data { aindex; bounds; _} ~pos =
-  let es = Alleles.Set.init aindex in
-  Alleles.Map.iter aindex bounds ~f:(fun sep_lst allele ->
+  let es = A.Set.init aindex in
+  A.Map.iter aindex bounds ~f:(fun sep_lst allele ->
     List.iter sep_lst ~f:(fun sep ->
       if (fst sep.start) <= pos && pos < sep.end_ then
-        Alleles.Set.set aindex es allele
+        A.Set.set aindex es allele
       (* No need to clear! *)));
   es
 
@@ -1191,12 +1253,12 @@ let search_through_gap g node ~pos =
 
 (*let find_root_position ({g; aindex; _} as gt) ~pos =
   let all_edges = alleles_with_data gt ~pos in
-  let root_allele = Alleles.Set.min_elt aindex all_edges in
+  let root_allele = A.Set.min_elt aindex all_edges in
   find_node_at ~next_if_gap:true gt root_allele ~pos >>=
     fun rootn ->
       if Nodes.position rootn > pos then begin  (* In a gap, work backwards! *)
         search_through_gap g rootn ~pos >>= fun (n, e) ->
-          let new_root_allele = Alleles.Set.min_elt aindex e in
+          let new_root_allele = A.Set.min_elt aindex e in
           Ok (new_root_allele, all_edges, n)
       end else
         Ok (root_allele, all_edges, rootn) *)
@@ -1225,7 +1287,7 @@ let node_set_to_string s =
 let edge_node_set_to_string ?max_length ?complement aindex s =
   EdgeNodeSet.fold ~f:(fun (e, n) a ->
     (sprintf "(%s -> %s)"
-      (Alleles.Set.to_human_readable aindex ?max_length ?complement e)
+      (A.Set.to_human_readable aindex ?max_length ?complement e)
       (Nodes.vertex_name n)) :: a) ~init:[] s
   |> String.concat ~sep:"; "
   |> sprintf "{%s}"
@@ -1236,7 +1298,7 @@ let edge_node_set_to_table ?max_length ?complement aindex s =
   |> List.map ~f:(fun (e, n) ->
       sprintf "%s <- %s"
         (Nodes.vertex_name n)
-        (Alleles.Set.to_human_readable aindex ?max_length ?complement e))
+        (A.Set.to_human_readable aindex ?max_length ?complement e))
   |> String.concat ~sep:"\n"
   |> sprintf "%s"
 
@@ -1389,8 +1451,8 @@ let adjacents_at ?max_edge_debug_length ?(max_height=10000) ({g; aindex; _} as g
         begin
           if !adjacents_debug_ref then
             eprintf "Still missing %s\n"
-              (Alleles.Set.to_human_readable ?max_length aindex
-                (Alleles.Set.diff all_edges es_acc));
+              (A.Set.to_human_readable ?max_length aindex
+                (A.Set.diff all_edges es_acc));
           false
         end
     in
@@ -1398,8 +1460,8 @@ let adjacents_at ?max_edge_debug_length ?(max_height=10000) ({g; aindex; _} as g
       if !adjacents_debug_ref then
         eprintf "Adding %s <- %s.\n"
           (Nodes.vertex_name node)
-          (Alleles.Set.to_human_readable ?max_length aindex edge);
-      Alleles.Set.union edge edge_set
+          (A.Set.to_human_readable ?max_length aindex edge);
+      A.Set.union edge edge_set
     in
-    let init = Alleles.Set.init aindex in
+    let init = A.Set.init aindex in
     Ok ( Adjacents.check_by_levels ~max_height ~init ~stop g rootn ~f)

--- a/src/scripts/load_A_graphs.ml
+++ b/src/scripts/load_A_graphs.ml
@@ -3,7 +3,8 @@
 open Common
 
 let file = to_alignment_file "A_nuc"
-let g2 = Ref_graph.(construct_from_file ~which:(NumberOfAlts 2) ~join_same_sequence:true file)
-let g3 = Ref_graph.(construct_from_file ~which:(NumberOfAlts 3) ~join_same_sequence:true file)
-let g20 = Ref_graph.(construct_from_file ~which:(NumberOfAlts 20) ~join_same_sequence:true file)
-let g_all = Ref_graph.(construct_from_file ~join_same_sequence:true file)
+let cff = Ref_graph.construct_from_file ~join_same_sequence:true ~remove_reference:false 
+let g2 = Ref_graph.(cff ~which:(NumberOfAlts 2) file)
+let g3 = Ref_graph.(cff ~which:(NumberOfAlts 3) file)
+let g20 = Ref_graph.(cff ~which:(NumberOfAlts 20) file)
+let g_all = Ref_graph.(cff file)


### PR DESCRIPTION
This fixes #6 as one can add `--ar "A\\*02:01:" --no-reference` to the command line to get the desired effect.