### PR TITLE
Use custom fixed width bitvectors for allele sets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,6 @@ matrix:
     - os: linux
       env: OCAML_VERSION=4.03 OPAM_VERSION=1.2.2 TEST=round
     - os: linux
-      env: OCAML_VERSION=4.03 OPAM_VERSION=1.2.2 TEST=mergeA
-    - os: linux
-      env: OCAML_VERSION=4.03 OPAM_VERSION=1.2.2 TEST=mergeB
-    - os: linux
-      env: OCAML_VERSION=4.03 OPAM_VERSION=1.2.2 TEST=mergeC
-    - os: linux
       env: OCAML_VERSION=4.03 OPAM_VERSION=1.2.2 TEST=alleleDiffA
     - os: linux
       env: OCAML_VERSION=4.03 OPAM_VERSION=1.2.2 TEST=biologicalKmers

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-PACKAGES=unix ppx_deriving.std nonstd sosa ocamlgraph cmdliner bitv biocaml.unix
-SETUP_PACKAGE_NAMES=ocamlfind ocamlbuild ppx_deriving.4.1 nonstd.0.0.2 sosa.0.2.0 ocamlgraph.1.8.6 cmdliner.1.0.0 bitv.1.2 biocaml.0.6.0
+PACKAGES=unix ppx_deriving.std nonstd sosa ocamlgraph cmdliner biocaml.unix
+SETUP_PACKAGE_NAMES=ocamlfind ocamlbuild ppx_deriving.4.1 nonstd.0.0.2 sosa.0.2.0 ocamlgraph.1.8.6 cmdliner.1.0.0 biocaml.0.6.0
 TOOLS=mhc2gpdf par_type align2fasta allele_distances
 TESTS=test_parsing round_trip adjacents benchmark_k merged_sensible_test mas_align_test test_allele_distances biological_kmers
 

--- a/src/app/common_options.ml
+++ b/src/app/common_options.ml
@@ -158,6 +158,7 @@ let num_alt_arg =
   (value & opt (some nconv) None & info ~doc ~docv num_command_line_args)
 
 (*** Other args. ***)
+(*
 let remove_reference_flag =
   let doc  = "Remove the reference allele from the graph. The reference \
               allele is the one that is listed first in the alignments file. \
@@ -168,6 +169,7 @@ let remove_reference_flag =
               the graph after the other alleles are added."
   in
   Arg.(value & flag & info ~doc ["no-reference"])
+  *)
 
 let impute_flag =
   let doc  = "Fill in the missing segments of alleles with an iterative \
@@ -205,13 +207,13 @@ let to_filename_and_graph_args
     ~without_list
     ?number_alleles
   (* Graph modifiers. *)
-  ~join_same_sequence ~remove_reference =
+  ~join_same_sequence =
     to_input ?alignment_file ?merge_file ~distance ~impute () >>= fun input ->
       let selectors =
         regex_list @ specific_list @ without_list @
           (match number_alleles with | None -> [] | Some s -> [s])
       in
-      let arg = {Ref_graph.selectors; join_same_sequence; remove_reference} in
+      let arg = {Ref_graph.selectors; join_same_sequence } in
       let graph_arg = Cache.graph_args ~arg ~input in
       let option_based_fname = Cache.graph_args_to_string graph_arg in
       Ok (option_based_fname, graph_arg)

--- a/src/app/mhc2gpdf.ml
+++ b/src/app/mhc2gpdf.ml
@@ -9,7 +9,7 @@ let construct
   (* allele selection. *)
   regex_list specific_list without_list number_alleles
   (* Construction args *)
-  remove_reference not_join_same_seq
+  not_join_same_seq
   (* output configuration. *)
   notshort no_pdf no_open skip_disk_cache max_edge_char_length
   not_human_edges not_compress_edges not_compress_start
@@ -21,8 +21,7 @@ let construct
     Common_options.to_filename_and_graph_args
       ?alignment_file ?merge_file ~distance ~impute
       ~specific_list ~regex_list ~without_list ?number_alleles
-      ~join_same_sequence ~remove_reference
-
+      ~join_same_sequence
   in
   match fname_cargs_result with
   | Error msg ->
@@ -126,7 +125,6 @@ let () =
             $ without_arg
             $ num_alt_arg
             (* construction args. *)
-            $ remove_reference_flag
             $ do_not_join_same_sequence_paths_flag
             (* output configuration *)
             $ not_short_flag $ no_pdf_flag $ no_open_flag

--- a/src/lib/alleles.ml
+++ b/src/lib/alleles.ml
@@ -21,6 +21,8 @@ let index lst =
   in
   { size; to_index; to_allele }
 
+let to_alleles { to_allele; _ } = Array.to_list to_allele
+
 module CompressNames = struct
 
   let split_colon = String.split ~on:(`Character ':')
@@ -122,68 +124,74 @@ module CompressNames = struct
 
 end  (* CompressNames *)
 
-let to_alleles { to_allele; _ } = Array.to_list to_allele
+let _index = ref
+  { size      = 0
+  ; to_index  = StringMap.empty
+  ; to_allele = [||]
+  }
+
+let setup i =
+  _index := i;
+  Fixed_width.setup i.size
 
 module Set = struct
 
-  type t = Bitv.t
+  type set = Fixed_width.t
 
-  let copy = Bitv.copy
+  let empty = Fixed_width.empty
 
-  let init {size; _} =
-    Bitv.create size false
+  let copy = Fixed_width.copy
 
-  (* This is necessary for graph construction. *)
-  let empty () = Bitv.create 0 false
+  let init () = Fixed_width.create false
 
-  let set { to_index; _ } s allele =
-    Bitv.set s (StringMap.find allele to_index) true;
+  let set s allele =
+    Fixed_width.set s (StringMap.find allele !_index.to_index);
     s
 
-  (*let unite ~into from = CCBV.union_into ~into from *)
+  let unite ~into from = Fixed_width.union_into ~into from
 
-  let singleton index allele =
-    let s = init index in
-    set index s allele
+  let singleton allele =
+    let s = init () in
+    set s allele
 
-  let clear { to_index; _ } s allele =
-    Bitv.set s (StringMap.find allele to_index) false;
+  let clear s allele =
+    Fixed_width.reset s (StringMap.find allele !_index.to_index);
     s
 
-  let is_set { to_index; _ } s allele =
-    Bitv.get s (StringMap.find allele to_index)
+  let is_set s allele =
+    Fixed_width.get s (StringMap.find allele !_index.to_index)
 
-  let fold { to_allele; } ~f ~init s =
+  let fold ~f ~init s =
     let r = ref init in
-    Bitv.iteri_true (fun i -> r := f !r to_allele.(i)) s;
+    Fixed_width.iter_true s (fun i -> r := f !r !_index.to_allele.(i));
     !r
 
-  let iter index ~f s =
-    fold index ~init:() ~f:(fun () a -> f a) s
+  let iter ~f s =
+    fold ~init:() ~f:(fun () a -> f a) s
 
-  let cardinal = Bitv.pop
+  let cardinal = Fixed_width.cardinal
 
   let compare = Pervasives.compare  (*?*)
 
   let equals = (=) (*?*)
 
-  let union = Bitv.bw_or
+  let union = Fixed_width.union
 
-  let inter = Bitv.bw_and
+  let inter = Fixed_width.inter
 
-  let diff x y = Bitv.bw_and x (Bitv.bw_not  y)
+  let diff = Fixed_width.diff
 
-  let complement = Bitv.bw_not
+  let complement = Fixed_width.negate
 
-  let to_string ?(compress=false) index s =
-    fold index ~f:(fun a s -> s :: a) ~init:[] s
+  let to_string ?(compress=false) s =
+    fold ~f:(fun a s -> s :: a) ~init:[] s
     |> List.rev
     |> (fun l -> if compress then CompressNames.f l else l)
     |> String.concat ~sep:";"
 
-  let complement_string ?(compress=false) ?prefix { to_allele; _} s =
-    Array.fold_left to_allele ~init:(0, [])
-        ~f:(fun (i, acc) a -> if Bitv.get s i
+  let complement_string ?(compress=false) ?prefix s =
+    Array.fold_left !_index.to_allele ~init:(0, [])
+        ~f:(fun (i, acc) a -> if Fixed_width.get s i
                               then (i + 1, acc)
                               else (i + 1, a :: acc))
     |> snd
@@ -196,20 +204,20 @@ module Set = struct
                  | None    -> s
                  | Some cp -> cp ^ s
 
-  let to_human_readable ?(compress=true) ?(max_length=500) ?(complement=`Yes) t s =
+  let to_human_readable ?(compress=true) ?(max_length=500) ?(complement=`Yes) s =
     let make_shorter =
-      let p = Bitv.pop s in
-      if p = t.size then
+      let p = cardinal s in
+      if p = !_index.size then
         "Everything"
       else if p = 0 then
         "Nothing"
-      else if p <= t.size / 2 then
-        to_string ~compress t s
+      else if p <= !_index.size / 2 then
+        to_string ~compress s
       else
         match complement with
-        | `Yes           -> complement_string ~compress ~prefix:"C. of " t s
-        | `Prefix prefix -> complement_string ~compress ~prefix t s
-        | `No            -> to_string ~compress t s
+        | `Yes           -> complement_string ~compress ~prefix:"C. of " s
+        | `Prefix prefix -> complement_string ~compress ~prefix s
+        | `No            -> to_string ~compress s
     in
     String.take make_shorter ~index:max_length
 
@@ -217,20 +225,18 @@ end (* Set *)
 
 module Map = struct
 
-  type 'a t = 'a array
+  type 'a map = 'a array
 
   let to_array a = a
 
-  let make { size; _} e =
-    Array.make size e
+  let make e =
+    Array.make !_index.size e
 
-  let init { size; to_allele; _} f =
-    Array.init size ~f:(fun i -> f to_allele.(i))
+  let init f =
+    Array.init !_index.size ~f:(fun i -> f !_index.to_allele.(i))
 
-  let get { to_index; _} m a =
-    m.(StringMap.find a to_index)
-
-  let cardinal = Array.length
+  let get m a =
+    m.(StringMap.find a !_index.to_index)
 
   let update2 ~source ~dest f =
     for i = 0 to Array.length source - 1 do
@@ -240,18 +246,18 @@ module Map = struct
   let map2_wa ~f m1 m2 =
     Array.init (Array.length m1) ~f:(fun i -> f m1.(i) m2.(i))
 
-  let fold { to_allele; size; _} ~f ~init amap =
+  let fold ~f ~init amap =
     let s = ref init in
-    for i = 0 to size - 1 do
-      s := f !s amap.(i) to_allele.(i)
+    for i = 0 to !_index.size - 1 do
+      s := f !s amap.(i) !_index.to_allele.(i)
     done;
     !s
 
-  let iter i ~f amap =
-    fold i ~init:() ~f:(fun () m a -> f m a) amap
+  let iter ~f amap =
+    fold ~init:() ~f:(fun () m a -> f m a) amap
 
-  let map { to_allele; _} ~f amap =
-    Array.mapi amap ~f:(fun i c -> f amap.(i) (to_allele.(i)))
+  let map ~f amap =
+    Array.mapi amap ~f:(fun i c -> f amap.(i) (!_index.to_allele.(i)))
 
   let fold_wa = Array.fold_left
 
@@ -260,26 +266,26 @@ module Map = struct
   let map_wa ~f amap =
     Array.map amap ~f
 
-  let values_assoc index amap =
+  let values_assoc amap =
     Array.fold_left amap ~init:(0, []) ~f:(fun (i, asc) v ->
-      let a = index.to_allele.(i) in
+      let a = !_index.to_allele.(i) in
       try
         let s, rest = remove_and_assoc v asc in
         (* TODO: make these modules recursive to allow maps to see inside sets *)
-        (i + 1, (v, Set.set index s a) :: rest)
+        (i + 1, (v, Set.set s a) :: rest)
       with Not_found ->
-        (i + 1, (v, Set.singleton index a) ::asc))
+        (i + 1, (v, Set.singleton a) ::asc))
     |> snd
 
   let update_from s ~f m =
-    Bitv.iteri_true (fun i -> m.(i) <- f m.(i)) s
+    Fixed_width.iter_true s (fun i -> m.(i) <- f m.(i))
 
   let update_from_and_fold s ~f ~init m =
     let r = ref init in
-    Bitv.iteri_true (fun i ->
+    Fixed_width.iter_true s (fun i ->
       let nm, nacc = f !r m.(i) in (* Use in 1st position ala fold_left. *)
       r := nacc;
-      m.(i) <- nm) s;
+      m.(i) <- nm);
     !r
 
   let choose m =

--- a/src/lib/alleles.ml
+++ b/src/lib/alleles.ml
@@ -134,6 +134,9 @@ let setup i =
   _index := i;
   Fixed_width.setup i.size
 
+let current () =
+  !_index
+
 module Set = struct
 
   type set = Fixed_width.t
@@ -180,6 +183,8 @@ module Set = struct
   let inter = Fixed_width.inter
 
   let diff = Fixed_width.diff
+
+  let inter_diff = Fixed_width.inter_diff
 
   let complement = Fixed_width.negate
 

--- a/src/lib/alleles.mli
+++ b/src/lib/alleles.mli
@@ -22,6 +22,10 @@ val to_alleles : index -> allele list
     Set or Map function. *)
 val setup : index -> unit
 
+(** Return the current setup index, it may be nonsensp
+. *)
+val current : unit -> index
+
 module Set : sig
 
   type set
@@ -72,6 +76,8 @@ module Set : sig
   (** [diff e1 e2] will return an edge set with alleles found in [e1] but not
       in [e2]. *)
   val diff : set -> set -> set
+
+  val inter_diff : set -> set -> set * set * bool * bool
 
   (** [complement set] returns a set of all the alleles not in [set].*)
   val complement : set -> set

--- a/src/lib/fixed_width.ml
+++ b/src/lib/fixed_width.ml
@@ -1,0 +1,249 @@
+(** Fixed width! Imperative Bitvectors
+
+    We implement fixed width bitvectors in a non-functional, poorly abstracted,
+    and error prone (doesn't check for size) on purpose. Computing bitvector
+    unions and diffs are pretty fundamental to many graph operations. Removing
+    the size check, makes sense when you're doing it thousands of times. But
+    caveat emptor! Make sure to call [setup] before ] before ] before calling
+    anything after it, listed lower in the source code.
+ *)
+
+let width_ = Sys.word_size - 1
+
+(** We use OCamls ints to store the bits. We index them from the
+    least significant bit. We create masks to zero out the most significant
+    bits that aren't used to store values. This is necessary when we are
+    constructing or negating a bit vector. *)
+let lsb_masks_ =
+  let a = Array.make (width_ + 1) 0 in
+  for i = 1 to width_ do
+    a.(i) <- a.(i-1) lor (1 lsl (i - 1))
+  done;
+  a
+
+let all_ones_ = lsb_masks_.(width_)
+
+(* count the 1 bits in [n]. See https://en.wikipedia.org/wiki/Hamming_weight *)
+let count_bits_ n =
+  let rec recurse count n =
+    if n = 0 then count else recurse (count+1) (n land (n-1))
+  in
+  recurse 0 n
+
+type t = {
+  mutable a : int array;
+}
+
+let empty = { a = [| |]  }
+
+let size = ref (-1)
+let mask = ref lsb_masks_.(0)
+let final_length = ref 0
+let array_length = ref (-1)
+let last_array_index = ref (!array_length - 1)
+
+let setup new_size =
+  begin
+    let r = new_size mod width_ in
+    size := new_size;
+    mask := lsb_masks_.(r);
+    final_length := if r = 0 then width_ else r;
+    array_length := (if new_size mod width_ = 0 then new_size / width_ else (new_size / width_) + 1);
+    last_array_index := !array_length - 1
+  end
+
+let create default =
+  let a = if default
+    then Array.make !array_length all_ones_
+    else Array.make !array_length 0
+  in
+  (* adjust last bits *)
+  if default && !mask <> 0 then Array.unsafe_set a !last_array_index !mask;
+  { a; }
+
+let copy bv = { a = Array.copy bv.a }
+
+let capacity = width_ * !array_length
+
+let cardinal bv =
+  let n = ref 0 in
+  for i = 0 to !last_array_index do
+    n := !n + count_bits_ bv.a.(i)         (* MSB of last element are all 0 *)
+  done;
+  !n
+
+let is_empty bv =
+  try
+    for i = 0 to !last_array_index do
+      if bv.a.(i) <> 0 then raise Exit     (* MSB of last element are all 0 *)
+    done;
+    true
+  with Exit ->
+    false
+
+(* Use the safe array access and throw an exception if out of bounds.
+    This can be compiled away with -unsafe. *)
+let get bv i =
+  let n = i / width_ in
+  let j = i mod width_ in
+  bv.a.(n) land (1 lsl j) <> 0
+
+let set bv i =
+  let n = i / width_ in
+  let j = i mod width_ in
+  bv.a.(n) <- bv.a.(n) lor (1 lsl j)
+
+let reset bv i =
+  let n = i / width_ in
+  let j = i mod width_ in
+  bv.a.(n) <- bv.a.(n) land (lnot (1 lsl j))
+
+let flip bv i =
+  let n = i / width_ in
+  let j = i mod width_ in
+  bv.a.(n) <- bv.a.(n) lxor (1 lsl j)
+
+let clear bv =
+  Array.fill bv.a 0 !array_length 0
+
+let iter bv f =
+  for n = 0 to !last_array_index - 1 do
+    let j = width_ * n in
+    for i = 0 to width_ - 1 do
+      let () = f (j+i) (bv.a.(n) land (1 lsl i) <> 0) in
+      ()
+    done
+  done;
+  let j = width_ * !last_array_index in
+  for i = 0 to !final_length - 1 do
+    let () = f (j + i) (bv.a.(!last_array_index) land (1 lsl i) <> 0) in
+    ()
+  done
+
+let iter_true bv f =
+  iter bv (fun i b -> if b then f i else ())
+
+let to_list bv =
+  let l = ref [] in
+  iter_true bv (fun i -> l := i :: !l);
+  !l
+
+let to_sorted_list bv =
+  List.rev (to_list bv)
+
+(* Interpret these as indices. *)
+let of_list l =
+  let bv = create false in
+  List.iter (set bv) l;
+  bv
+
+exception FoundFirst of int
+
+let first_exn bv =
+  try
+    iter_true bv (fun i -> raise (FoundFirst i));
+    raise Not_found
+  with FoundFirst i ->
+    i
+
+let first bv =
+  try Some (first_exn bv)
+  with Not_found -> None
+
+let filter bv p =
+  iter_true bv
+    (fun i -> if not (p i) then reset bv i)
+
+let negate_self b =
+  for n = 0 to !last_array_index do
+    Array.unsafe_set b.a n (lnot (Array.unsafe_get b.a n))
+  done;
+  if !mask <> 0 then
+    Array.unsafe_set b.a !last_array_index
+      (!mask land (Array.unsafe_get b.a !last_array_index))
+
+let negate b =
+  let a = Array.map (lnot) b.a in
+  if !mask <> 0 then begin
+    Array.unsafe_set a !last_array_index
+      (!mask land (Array.unsafe_get a !last_array_index))
+  end;
+  { a }
+
+let union_into ~into bv =
+  for i = 0 to !last_array_index do
+    Array.unsafe_set into.a i
+      ((Array.unsafe_get into.a i) lor (Array.unsafe_get bv.a i))
+  done
+
+(* To avoid potentially 2 passes, figure out what we need to copy. *)
+let union b1 b2 =
+  let into = copy b1 in
+  union_into ~into b2;
+  into
+
+(* Underlying size shrinks for inter. *)
+let inter_into ~into bv =
+  for i = 0 to !last_array_index do
+    Array.unsafe_set into.a i
+      ((Array.unsafe_get into.a i) land (Array.unsafe_get bv.a i))
+  done
+
+let inter b1 b2 =
+  let into = copy b1 in
+  inter_into ~into b2;
+  into
+
+let diff_into ~into bv =
+  for i = 0 to !last_array_index do
+    Array.unsafe_set into.a i
+      ((Array.unsafe_get into.a i) land (lnot (Array.unsafe_get bv.a i)))
+  done
+
+let diff in_ not_in =
+  let into = copy in_ in
+  diff_into ~into not_in;
+  into
+
+let select bv arr =
+  let l = ref [] in
+  begin try
+      iter_true bv
+        (fun i ->
+          if i >= !last_array_index
+          then raise Exit
+          else l := arr.(i) :: !l)
+    with Exit -> ()
+  end;
+  !l
+
+let selecti bv arr =
+  let l = ref [] in
+  begin try
+      iter_true bv
+        (fun i ->
+          if i >= !array_length
+          then raise Exit
+          else l := (arr.(i), i) :: !l)
+    with Exit -> ()
+  end;
+  !l
+
+type 'a sequence = ('a -> unit) -> unit
+
+let to_seq bv k = iter_true bv k
+
+let of_seq seq =
+  let l = ref [] and maxi = ref 0 in
+  seq (fun x -> l := x :: !l; maxi := max !maxi x);
+  let bv = create false in
+  List.iter (fun i -> set bv i) !l;
+  bv
+
+let print out bv =
+  Format.pp_print_string out "bv {";
+  iter bv
+    (fun _i b ->
+      Format.pp_print_char out (if b then '1' else '0')
+    );
+  Format.pp_print_string out "}"

--- a/src/lib/fixed_width.ml
+++ b/src/lib/fixed_width.ml
@@ -205,6 +205,23 @@ let diff in_ not_in =
   diff_into ~into not_in;
   into
 
+let inter_diff b1 b2 =
+  let inter_into = copy b1 in
+  let diff_into  = copy b1 in
+  let same = ref true in
+  let no_i = ref true in   (* no intersection? *)
+  for i = 0 to !last_array_index do
+    let b1i = Array.unsafe_get inter_into.a i in
+    let b2i = Array.unsafe_get b2.a i in
+    let ii  = b1i land b2i in
+    let di  = b1i land (lnot b2i) in
+    Array.unsafe_set inter_into.a i ii;
+    Array.unsafe_set diff_into.a i di;
+    same := !same && ii = b1i;
+    no_i := !no_i && ii = 0;
+  done;
+  inter_into, diff_into, !same, !no_i
+
 let select bv arr =
   let l = ref [] in
   begin try

--- a/src/lib/index.ml
+++ b/src/lib/index.ml
@@ -130,7 +130,7 @@ let fold_over_biological_kmers_in_graph ~k ~init ~absorb ~extend ~close g =
     G.fold_pred_e (fun (_,e,_) a -> Alleles.Set.union e a) g.g n
       (Alleles.Set.init g.aindex)
   in *)
-  let everything = Alleles.Set.(complement (init g.aindex)) in
+  let everything = Alleles.Set.(complement (init ())) in
   let proc node state =
     match node with
     | S _ | E _ | B _ -> state

--- a/src/lib/parPHMM.ml
+++ b/src/lib/parPHMM.ml
@@ -179,9 +179,9 @@ type position_map = (Mas_parser.position * int) list
   The mapping (position into base_state array) is then recovered by iterating
   over this position map as we move along Mas_parser.alignment_element's for
   the alleles. *)
-let initialize_base_array_and_position_map ali reference ref_elems =
+let initialize_base_array_and_position_map reference ref_elems =
   let open Mas_parser in
-  let ref_set () = Alleles.Set.singleton ali reference in
+  let ref_set () = Alleles.Set.singleton reference in
   let sequence_to_base_states_array prev_state s =
     String.to_character_list s
     |> List.mapi ~f:(fun i c ->
@@ -258,28 +258,28 @@ let rec position_and_advance sp (pos_map : position_map) =
   | h :: t                                            -> position_and_advance sp t
 
 (* Add an allele's Mas_parser.sequence to the current run-length encoded state. *)
-let add_alternate_allele ali reference ~position_map allele allele_instr arr =
+let add_alternate_allele reference ~position_map allele allele_instr arr =
   let base_and_offset b o ((bp,bo), _) = b = bp && o = bo in
   let add_to_base_state i b o =
     (*printf "adding base at %d %c %d\n" i (BaseState.to_char b) o; *)
     match List.find arr.(i) ~f:(base_and_offset b o) with
-    | None              -> let s = Alleles.Set.singleton ali allele in
+    | None              -> let s = Alleles.Set.singleton allele in
                            (*printf "single cell at %d for %s \n"  i allele; *)
                            arr.(i) <- ((b, o), s) :: arr.(i)
-    | Some ((ab,ro), s) -> (*printf "At: %d %s to %s\n"  i allele (Alleles.Set.to_string ali s); *)
-                           ignore (Alleles.Set.set ali s allele)
+    | Some ((ab,ro), s) -> (*printf "At: %d %s to %s\n"  i allele (Alleles.Set.to_string s); *)
+                           ignore (Alleles.Set.set s allele)
   in
-  let is_reference_set (_, s) = Alleles.Set.is_set ali s reference in
+  let has_reference_set (_, s) = Alleles.Set.is_set s reference in
   let add_to_reference_set offset start end_ =
     (*printf "adding reference set at %d %d %d\n" offset start end_; *)
     let rec loop i offset =
       if i = end_ then offset else begin
-        match List.find arr.(i) ~f:is_reference_set with
+        match List.find arr.(i) ~f:has_reference_set with
         | None              -> (* Reference in gap -> so are we! *)
                                loop (i + 1) (-1)  (* Offset becomes -1 after 1st use! *)
         | Some ((rb,ro), s) ->
             if ro = offset then begin
-              ignore (Alleles.Set.set ali s allele);
+              ignore (Alleles.Set.set s allele);
               loop (i + 1) (-1)
             end else begin
               add_to_base_state i rb offset;
@@ -348,7 +348,7 @@ module type Ring = sig
 
 end (* Ring *)
 
-type emissions = ((BaseState.t * int) * Alleles.Set.t) list
+type emissions = ((BaseState.t * int) * Alleles.Set.set) list
 (* For every k there are 3 possible states. *)
 
 type 'a cell =
@@ -357,8 +357,8 @@ type 'a cell =
   ; delete  : 'a
   }
 
-type 'a entry = (Alleles.Set.t * 'a cell) list
-type 'a final_entry = (Alleles.Set.t * 'a) list
+type 'a entry = (Alleles.Set.set * 'a cell) list
+type 'a final_entry = (Alleles.Set.set * 'a) list
 
 type workspace =
   { mutable forward             : float entry array array
@@ -375,14 +375,14 @@ let generate_workspace number_alleles bigK read_size =
 
 type 'a fwd_recurrences =
   { start     :  char -> float -> emissions -> 'a entry
-  ; first_row : 'a entry array array -> Alleles.index -> char -> float ->
+  ; first_row : 'a entry array array -> char -> float ->
                   emissions -> i:int -> 'a entry
-  ; middle    : 'a entry array array -> Alleles.index -> char -> float ->
+  ; middle    : 'a entry array array -> char -> float ->
                   emissions -> i:int -> k:int -> 'a entry
   (* Doesn't use the delete section. *)
   ; end_      : 'a entry array array -> int -> 'a final_entry
 
-  ; emission  : 'a final_entry array -> Alleles.index -> 'a array
+  ; emission  : 'a final_entry array -> 'a array
 
 (* Combine emission results *)
   ; combine   : into:'a array -> 'a array -> unit
@@ -415,9 +415,9 @@ let mutate_or_add value allele_set lst =
 
 let debug_set_assoc = ref false
 
-let set_assoc ali to_find slst =
+let set_assoc to_find slst =
   if !debug_set_assoc then printf "set_assoc %d\n" (List.length slst);
-  let to_s = Alleles.Set.to_string ali in
+  let to_s = Alleles.Set.to_string in
   let rec loop to_find acc = function
     | []          -> invalid_argf "Still missing! %s after looking in: %s"
                       (to_s to_find) (List.map slst ~f:(fun (s,_) -> to_s s) |> String.concat ~sep:"\n\t")
@@ -496,8 +496,7 @@ module ForwardGen (R : Ring) = struct
                         ; delete = zero
                         })
                 end
-    ; first_row = begin fun fm ali base base_error emissions ~i ->
-                    let set_assoc = set_assoc ali in
+    ; first_row = begin fun fm base base_error emissions ~i ->
                     List.fold_left emissions ~init:[]
                       ~f:(fun acc ((b, offset), allele_set) ->
                             let emp = to_match_prob base base_error b in
@@ -514,8 +513,7 @@ module ForwardGen (R : Ring) = struct
                               ; delete = t_m_d * zero + t_d_d * zero
                               } als acc))
                   end
-    ; middle  = begin fun fm ali base base_error emissions ~i ~k ->
-                  let set_assoc = set_assoc ali in
+    ; middle  = begin fun fm base base_error emissions ~i ~k ->
                   List.fold_left emissions ~init:[]
                     ~f:(fun acc ((b, offset), allele_set) ->
                           let emp = to_match_prob base base_error b in
@@ -547,8 +545,8 @@ module ForwardGen (R : Ring) = struct
                   List.map fc ~f:(fun (allele_set, c) ->
                     allele_set, (c.match_ * t_m_s + c.insert * t_i_s))
                 end
-    ; emission  = begin fun final ali ->
-                    let ret = Alleles.Map.make ali zero in
+    ; emission  = begin fun final ->
+                    let ret = Alleles.Map.make zero in
                     Array.iter final ~f:(fun l ->
                       List.iter l ~f:(fun (allele_set, v) ->
                         Alleles.Map.update_from allele_set ~f:((+) v) ret));
@@ -687,10 +685,11 @@ let construct input selectors =
       in
       let alleles = mp.reference :: List.map ~f:fst nalt_elems in
       let allele_index = Alleles.index alleles in
-      let ems, position_map = initialize_base_array_and_position_map
-        allele_index mp.reference mp.ref_elems
+      let () = Alleles.setup allele_index in
+      let ems, position_map =
+        initialize_base_array_and_position_map mp.reference mp.ref_elems
       in
-      let aaa = add_alternate_allele allele_index mp.reference ~position_map in
+      let aaa = add_alternate_allele mp.reference ~position_map in
       List.iter ~f:(fun (allele, altseq) -> aaa allele altseq ems) nalt_elems;
       Ok { align_date = mp.align_date
          ; allele_index
@@ -740,7 +739,7 @@ let forward_pass ?(logspace=true) ?ws { allele_index; emissions_a } read_size =
       let base = String.get_exn read i in
       let base_prob = read_prob.(i) in
       ws.forward.(0).(i) <-
-        recurrences.first_row ws.forward allele_index base base_prob ~i emissions_a.(0)
+        recurrences.first_row ws.forward base base_prob ~i emissions_a.(0)
     done;
     (* All other rows. *)
     for k = 1 to bigK - 1 do
@@ -751,13 +750,13 @@ let forward_pass ?(logspace=true) ?ws { allele_index; emissions_a } read_size =
         let base = String.get_exn read i in
         let base_prob = read_prob.(i) in
         ws.forward.(k).(i) <-
-          recurrences.middle ws.forward allele_index base base_prob ~i ~k ek
+          recurrences.middle ws.forward base base_prob ~i ~k ek
       done
     done;
     for k = 0 to bigK - 1 do
       ws.final.(k) <- recurrences.end_ ws.forward k
     done;
-    ws.per_allele_emission <- recurrences.emission ws.final allele_index;
+    ws.per_allele_emission <- recurrences.emission ws.final;
     recurrences.combine ~into ws.per_allele_emission;
     if !debug_ref then save_workspace ws;
     into

--- a/src/lib/parPHMM.ml
+++ b/src/lib/parPHMM.ml
@@ -422,23 +422,16 @@ let set_assoc to_find slst =
     | []          -> invalid_argf "Still missing! %s after looking in: %s"
                       (to_s to_find) (List.map slst ~f:(fun (s,_) -> to_s s) |> String.concat ~sep:"\n\t")
     | (s, v) :: t ->
-        let inter = Alleles.Set.inter s to_find in
-        let still_to_find = Alleles.Set.diff to_find s in
-        if !debug_set_assoc then
-          printf "For\t%s\n\
-                  in\t%s\n\
-                  found\t%s\n\
-                  butnot\t%s\n"
-            (to_s to_find)
-            (to_s s)
-            (to_s inter)
-            (to_s still_to_find);
-        if inter = to_find then                         (* Found everything *)
+        let inter, still_to_find, same_intersect, no_intersect =
+          Alleles.Set.inter_diff to_find s in
+
+        if same_intersect then begin                        (* Found everything *)
           (to_find, v) :: acc
-        else if Alleles.Set.cardinal inter = 0 then       (* Found nothing. *)
+        end else if no_intersect then begin       (* Found nothing. *)
           loop to_find acc t
-        else                                            (* Found something. *)
+        end else begin                                         (* Found something. *)
           loop still_to_find ((inter, v) :: acc) t
+        end
   in
   loop to_find [] slst
 

--- a/src/lib/prohlatype.mllib
+++ b/src/lib/prohlatype.mllib
@@ -1,1 +1,1 @@
-Util Phmm Nomenclature Mas_parser Merge_mas Distances Kmer_to_int Kmer_table Alleles ParPHMM Ref_graph Index Cache Fastq Fasta Compress
+Util Phmm Nomenclature Mas_parser Merge_mas Distances Kmer_to_int Kmer_table Fixed_width Alleles ParPHMM Ref_graph Index Cache Fastq Fasta Compress

--- a/src/scripts/adjacents.ml
+++ b/src/scripts/adjacents.ml
@@ -3,13 +3,13 @@
 open Util
 open Common
 
-let adjacents_at_test { Ref_graph.g; aindex; offset; posarr; bounds} ~pos =
-  Ref_graph.adjacents_at_private g aindex offset posarr bounds ~pos
+let adjacents_at_test { Ref_graph.g; offset; posarr; bounds} ~pos =
+  Ref_graph.adjacents_at_private g offset posarr bounds ~pos
 
 let test_graph file g pos =
   let open Ref_graph in
   let (edge_node_set, _, _) = adjacents_at_test g ~pos in
-  print_endline (EdgeNodeSet.to_table g.aindex edge_node_set)
+  print_endline (EdgeNodeSet.to_table edge_node_set)
 
 let test_graph_fail file g pos =
   let open Ref_graph in


### PR DESCRIPTION
This PR addresses the current major hotspot in the ParPHMM computation: allele union and difference passes. We use a custom bitvector implementation, in Fixed_width, that is as simple as possible but not properly abstracted. The user MUST specify the length before using the bitvectors, or out of bounds errors will surface. The resulting code reduces the per-read running time by about 40%!

The underlying code is simplified as we no longer have to pass around the Allele.index everywhere. Also of note, we remove the ability to remove the reference for graph construction. A small price to pay in my opinion. 