### PR TITLE
Implement a past likelihood threshold filter.

### DIFF
--- a/src/app/common_options.ml
+++ b/src/app/common_options.ml
@@ -479,3 +479,10 @@ let forward_pass_accuracy_arg =
   in
   Arg.(value & opt (some positive_float) None
              & info ~doc ~docv ["numerical-accuracy"])
+
+let do_not_past_threshold_filter_flag =
+  let doc = "Do not use previously calculated likelihoods (ex. from other loci \
+             or considering the reverse complement alignment) as a threshold \
+             filter to short-circuit evaluations."
+  in
+  Arg.(value & flag & info ~doc ["do-not-past-threshold-filter"])

--- a/src/scripts/profile.ml
+++ b/src/scripts/profile.ml
@@ -141,3 +141,22 @@ let best ~gene r k =
   let d = List.length cr in
   let n = List.length (List.filter cr ~f:(fun (_, l) -> List.hd_exn l < k)) in
   (n, d, (float n) /. (float d))
+
+let get_times fname =
+  let ic = open_in fname in
+  let rec loop acc =
+    try
+      loop (input_line ic :: acc)
+    with End_of_file ->
+      List.take acc 3
+  in
+  let last_three = loop [] in
+  close_in ic;
+  last_three
+
+let load_times ~dir ~fname_to_key =
+  Sys.readdir dir
+  |> Array.fold_left ~init:[] ~f:(fun acc file ->
+      let k = fname_to_key file in
+      let t = get_times (Filename.concat dir file) in
+      (k, t) :: acc)


### PR DESCRIPTION
Use the maximum seen match likelihood as a threshold for subsequent
calculations, whether for comparing against reverse complement or other
loci.